### PR TITLE
Use Zookeeper as the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ $ mix deps.get
 ## Tests
 
 ```sh
+$ epmd -daemon # to allow port mappings and things
 $ mix test
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-config :highlander, zookeeper_host: "127.0.0.1:2181"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,4 +2,6 @@ use Mix.Config
 
 config :highlander, zookeeper_host: "127.0.0.1:2181"
 
+config :highlander, :redis_host, "redis://127.0.0.1:6379/0"
+
 config :highlander, :spawn_nodes, [:"node1@127.0.0.1", :"node2@127.0.0.1"]

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 config :highlander, zookeeper_host: "127.0.0.1:2181"
 
-config :highlander, :nodes, [:"node1@127.0.0.1", :"node2@127.0.0.1"]
+config :highlander, :spawn_nodes, [:"node1@127.0.0.1", :"node2@127.0.0.1"]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :highlander, zookeeper_host: "127.0.0.1:2181"
+
+config :highlander, :nodes, [:"node1@127.0.0.1", :"node2@127.0.0.1"]

--- a/lib/highlander/registry.ex
+++ b/lib/highlander/registry.ex
@@ -2,12 +2,35 @@ defmodule Highlander.Registry do
   require Logger
   alias Highlander.Registry.Server
 
+  @timeout 500
+
   def hostname do
     GenServer.call(Server, {:hostname})
   end
 
+  # A safe way to run a function on another node (must share the same code)
+  def call(node, func) when is_atom(node) do
+    parent = self
+    ref = make_ref
+
+    pid = Node.spawn_link(node, fn ->
+      result = func.()
+      Kernel.send parent, {ref, result}
+      ref = Process.monitor(parent)
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      end
+    end)
+
+    receive do
+      {^ref, result} -> result
+    after
+      @timeout -> {pid, {:error, :timeout}}
+    end
+  end
+
   # A safe way to call other processes that will not crash if the other process is not found
-  def call(via, message) do
+  def call({:via, _, _} = via, message) do
     try do
       {:ok, GenServer.call(via, message)}
     catch
@@ -16,7 +39,7 @@ defmodule Highlander.Registry do
     end
   end
 
-  def lookup(via) do
+  def lookup({:via, _, _} = via) do
     GenServer.whereis(via)
   end
 
@@ -34,15 +57,18 @@ defmodule Highlander.Registry do
     end
   end
 
-  def whereis_name(name) do
-    GenServer.call(Server, {:whereis_name, name})
+  def whereis_name(name, opts \\ []) do
+    Logger.debug "#{node} whereis_name: #{inspect name}"
+    GenServer.call(Server, {:whereis_name, name, opts})
   end
 
   def register_name(name, pid) do
+    Logger.debug "#{node} register_name: #{inspect name}"
     GenServer.call(Server, {:register_name, name, pid})
   end
 
   def unregister_name(name) do
+    Logger.debug "#{node} unregister_name: #{inspect name}"
     GenServer.cast(Server, {:unregister_name, name})
   end
 end

--- a/lib/highlander/registry/node_cycle.ex
+++ b/lib/highlander/registry/node_cycle.ex
@@ -1,0 +1,26 @@
+defmodule Highlander.Registry.NodeCycleServer do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link __MODULE__, [], name: __MODULE__
+  end
+
+  def init(_) do
+    {:ok, %{nodes: Node.list(:known), index: 0}}
+  end
+
+  def handle_call(:next, _from, %{nodes: nodes, index: index} = state) do
+    index = index + 1
+
+    {node_name, nodes, index} = case Enum.fetch(nodes, index) do
+      {:ok, value} -> {value, nodes, index}
+      :error ->
+        index = 0
+        nodes = Node.list(:known)
+        {List.first(nodes), nodes, index}
+    end
+
+    new_state = %{state | nodes: nodes, index: index}
+    {:reply, node_name, new_state}
+  end
+end

--- a/lib/highlander/registry/server.ex
+++ b/lib/highlander/registry/server.ex
@@ -100,10 +100,13 @@ defmodule Highlander.Registry.Server do
     case resolve(node_name) do
       :unreachable ->
         Logger.debug "#{node} -> #{node_name} is unreachable"
-        {:error, :unreachable}
+        :undefined
       node ->
         Logger.debug "#{node} found #{node_name}: #{inspect([name, node])}"
-        Registry.call node, fn -> Registry.whereis_name(name, local: true) end
+        case :rpc.call(node, Registry, :whereis_name, [name, local: true]) do
+          {:badrpc, _reason} -> :undefined
+          result -> result
+        end
     end
   end
 

--- a/lib/highlander/registry/server.ex
+++ b/lib/highlander/registry/server.ex
@@ -1,4 +1,5 @@
 defmodule Highlander.Registry.Server do
+  alias Highlander.Registry
   alias Highlander.Registry.ZK
   use GenServer
   require Logger
@@ -11,83 +12,143 @@ defmodule Highlander.Registry.Server do
     pids = %{}
     names = %{}
 
-    {:ok, %{pids: pids, names: names}}
+    {:ok, %{server_pids: pids, names: names}}
   end
 
-  def add(state, {type, id} = name, pid) when is_pid(pid) and is_atom(type) and is_binary(id) do
+  defp add(state, {type, id} = name, %{server_pid: server_pid} = info) when is_pid(server_pid) and is_atom(type) and is_binary(id) do
     state
-    |> put_in([:pids, name], pid)
-    |> put_in([:names, pid], name)
+    |> put_in([:server_pids, server_pid], name) # to make it easier to lookup by server_pid in case that server goes down
+    |> put_in([:names, name], info)
   end
 
-  def delete(%{pids: pids, names: names} = state, {type, id} = name) when is_atom(type) and is_binary(id) do
-    pid = Map.get pids, name
-    new_pids = Map.delete pids, name
-    new_names = Map.delete names, pid
+  defp delete(state, {type, id} = name) when is_atom(type) and is_binary(id) do
+    case Map.get(state.names, name) do
+      %{server_pid: server_pid} ->
+        new_server_pids = Map.delete state.server_pids, server_pid
+        new_names = Map.delete state.names, name
 
-    %{state | pids: new_pids, names: new_names}
+        %{state | server_pids: new_server_pids, names: new_names}
+      nil -> state
+    end
   end
 
-  def delete(%{names: names} = state, pid) when is_pid(pid) do
-    name = Map.get names, pid
-    delete state, name
+  defp info(state, name) do
+    Map.get(state.names, name, :undefined)
   end
 
-  def delete(state, nil) do
-    Logger.error "Attempting to delete nil from the registry state"
-    state
+  defp name(state, pid) when is_pid(pid) do
+    Map.get(state.server_pids, pid)
   end
 
-  def resolve(hostname) when is_binary(hostname) do
-    if hostname == to_string(Node.self) do
+  defp server_pid(state, name) do
+    case info(state, name) do
+      :undefined -> :undefined
+      %{server_pid: server_pid} -> server_pid
+    end
+  end
+
+  defp register(state, name, pid) do
+    case server_pid(state, name) do
+      :undefined ->
+        Logger.debug "#{node} registering #{inspect pid} in state.pids"
+        Process.monitor pid
+        case ZK.create_znode(name) do
+          {:ok, zk_pid} ->
+            info = %{server_pid: pid, zk_pid: zk_pid}
+            Logger.debug "#{node} adding #{inspect name}/(#{inspect info}) to state.pids"
+            {:ok, add(state, name, info)}
+          {:error, reason} ->
+            Logger.debug "#{node} there was an error creating the zookeeper node for #{inspect name}: #{inspect reason} (not updating state.pids)"
+            {:error, reason, state}
+        end
+      _ ->
+        Logger.debug "#{node} register_name: already registered #{inspect name} in state.pids"
+        {:error, :already_registered, state}
+    end
+  end
+
+  defp unregister(state, { _type, _id } = name) do
+    Logger.debug "#{node} remove(#{inspect name})"
+    case info(state, name) do
+      :undefined ->
+        Logger.debug "#{node} not in my state.pids"
+        state
+      %{server_pid: server_pid, zk_pid: zk_pid} ->
+        Logger.debug "#{node} in my state.pids: #{inspect server_pid}"
+        :ok = ZK.delete_znode(zk_pid)
+        delete(state, name)
+    end
+  end
+
+  defp unregister(state, pid) when is_pid(pid) do
+    unregister(state, name(state, pid))
+  end
+
+  defp unregister(state, nil), do: state
+
+  defp resolve(node_name) when is_binary(node_name) do
+    if node_name == to_string(Node.self) do
       Node.self
     else
-      nodes = Node.list(:known)
-      Enum.find nodes, :unreachable, &(hostname == to_string(&1))
+      Node.list(:known)
+      |> Enum.find(:unreachable, &(node_name == to_string(&1)))
     end
   end
-  def resolve(nil), do: nil
+  defp resolve(nil), do: nil
 
-  defp whereis_node(hostname, name) do
-    case resolve(hostname) do
-      :unreachable -> {:error, :unreachable}
-      node -> {name, node}
-    end
-  end
-
-  defp whereis_hostname(name) do
-    case ZK.get_hostname(name) do
-      :undefined -> :undefined
-      hostname -> whereis_node(hostname, name)
+  defp whereis_on_node(node_name, name) do
+    case resolve(node_name) do
+      :unreachable ->
+        Logger.debug "#{node} -> #{node_name} is unreachable"
+        {:error, :unreachable}
+      node ->
+        Logger.debug "#{node} found #{node_name}: #{inspect([name, node])}"
+        Registry.call node, fn -> Registry.whereis_name(name, local: true) end
     end
   end
 
-  def handle_call({:whereis_name, name}, _from, state) do
-    case Map.get(state.pids, name, :undefined) do
-      :undefined -> {:reply, whereis_hostname(name), state}
-      pid -> {:reply, pid, state}
+  defp whereis_remote(name) do
+    case ZK.get_node_name(name) do
+      :undefined ->
+        Logger.debug "#{node} didn't find #{inspect name} in zookeeper"
+        :undefined
+      node_name ->
+        Logger.debug "#{node} found #{inspect name} in zookeeper: #{inspect node_name}"
+        whereis_on_node(node_name, name)
     end
   end
 
-  def handle_call({:register_name, name, pid}, _from, %{pids: pids} = state) do
-    case Map.get(pids, name) do
-      nil ->
-        Process.monitor pid
-        new_state = add state, name, pid
-        {:reply, :yes, new_state}
-      _ ->
-        {:reply, :no, state}
+  def handle_call({:whereis_name, name, opts}, _from, state) do
+    Logger.debug "#{node} handle_call whereis_name: #{inspect name}"
+    case info(state, name) do
+      :undefined ->
+        if opts[:local] do
+          {:reply, :undefined, state}
+        else
+          Logger.debug "#{node} not in my state.pids"
+          {:reply, whereis_remote(name), state}
+        end
+      %{server_pid: server_pid} ->
+        Logger.debug "#{node} in my state.pids: #{inspect server_pid}"
+        {:reply, server_pid, state}
+    end
+  end
+
+  def handle_call({:register_name, name, pid}, _from, state) do
+    case register(state, name, pid) do
+      {:ok, state} -> {:reply, :yes, state}
+      {:error, _reason, state} -> {:reply, :no, state}
     end
   end
 
   def handle_cast({:unregister_name, name}, state) do
-    new_state = delete state, name
-    {:noreply, new_state}
+    Logger.debug "#{node} unregister_name: #{inspect name}"
+    {:noreply, unregister(state, name)}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    new_state = delete state, pid
-    {:noreply, new_state}
+    Logger.debug "#{node} :DOWN: #{inspect pid}"
+    {:noreply, unregister(state, pid)}
   end
 
   def terminate(reason, _state) do

--- a/lib/highlander/registry/zk.ex
+++ b/lib/highlander/registry/zk.ex
@@ -1,0 +1,38 @@
+defmodule Highlander.Registry.ZK do
+  import Highlander.Registry.ZK.Helpers
+  alias Highlander.Registry.ZK.Node
+
+  def create_node({ type, _id } = name) when is_atom(type) do
+    Node.start_link(name)
+  end
+
+  def get_children({ type, _id } = name) when is_atom(type) do
+    case Zookeeper.Client.get_children(:zk, path(name)) do
+      {:ok, children } -> children
+      {:error, :no_node} -> []
+    end
+  end
+
+  def get_first({ type, _id } = name) when is_atom(type) do
+    get_children(name)
+    |> sort
+    |> first
+  end
+
+  def get_hostname({ type, _id } = name) when is_atom(type) do
+    get_hostname(name, get_first(name))
+  end
+
+  def get_hostname(_name, nil), do: :undefined
+
+  def get_hostname({ type, _id } = name, node_name) when is_atom(type) and is_binary(node_name) do
+    case Zookeeper.Client.get(:zk, path(name, node_name)) do
+      {:ok, value} -> value
+      _ -> :undefined
+    end
+  end
+
+  def first?({ type, _id } = name, << _ :: size(256), "-", _ :: binary >> = node_name) when is_atom(type) do
+    get_first(path(name)) == node_name
+  end
+end

--- a/lib/highlander/registry/zk.ex
+++ b/lib/highlander/registry/zk.ex
@@ -1,9 +1,21 @@
 defmodule Highlander.Registry.ZK do
+  require Logger
   import Highlander.Registry.ZK.Helpers
-  alias Highlander.Registry.ZK.Node
+  alias Highlander.Registry.ZK.ZNode
 
-  def create_node({ type, _id } = name) when is_atom(type) do
-    Node.start_link(name)
+  def create_znode({ type, _id } = name) when is_atom(type) do
+    {:ok, pid} = ZNode.start_link(name)
+
+    if ZNode.first?(pid) do
+      {:ok, pid}
+    else
+      :ok = ZNode.delete(pid)
+      {:error, :already_exists}
+    end
+  end
+
+  def delete_znode(pid) when is_pid(pid) do
+    :ok = ZNode.delete(pid)
   end
 
   def get_children({ type, _id } = name) when is_atom(type) do
@@ -19,20 +31,22 @@ defmodule Highlander.Registry.ZK do
     |> first
   end
 
-  def get_hostname({ type, _id } = name) when is_atom(type) do
-    get_hostname(name, get_first(name))
+  def get_node_name({ type, _id } = name) when is_atom(type) do
+    get_node_name(name, get_first(name))
   end
 
-  def get_hostname(_name, nil), do: :undefined
+  def get_node_name(_name, nil), do: :undefined
 
-  def get_hostname({ type, _id } = name, node_name) when is_atom(type) and is_binary(node_name) do
-    case Zookeeper.Client.get(:zk, path(name, node_name)) do
-      {:ok, value} -> value
+  def get_node_name({ type, _id } = name, znode_name) when is_atom(type) and is_binary(znode_name) do
+    case Zookeeper.Client.get(:zk, path(name, znode_name)) do
+      {:ok, {value, _stat}} ->
+        Logger.debug "#{node} value in zookeeper for #{path(name, znode_name)}: #{inspect value}"
+        value
       _ -> :undefined
     end
   end
 
-  def first?({ type, _id } = name, << _ :: size(256), "-", _ :: binary >> = node_name) when is_atom(type) do
-    get_first(path(name)) == node_name
+  def first?({ type, _id } = name, << _ :: size(256), "-", _ :: binary >> = znode_name) when is_atom(type) do
+    get_first(name) == znode_name
   end
 end

--- a/lib/highlander/registry/zk/helpers.ex
+++ b/lib/highlander/registry/zk/helpers.ex
@@ -2,19 +2,21 @@ defmodule Highlander.Registry.ZK.Helpers do
   @base_path "/__shared_objects__"
 
   def path({ type, id }) when is_atom(type) do
-    "#{@base_path}/#{type}/#{id}/"
+    "#{@base_path}/#{type}/#{id}"
   end
 
-  def path({ type, _id} = name, << _ :: size(256), "-", _ :: binary >> = node_name) when is_atom(type) do
-    "#{path(name)}/#{node_name}"
-  end
-
-  def prefix({ type, _id} = name, << uuid :: size(256) >>) when is_atom(type) do
+  def prefix({ type, _id} = name, << _ :: size(256) >> = uuid) when is_atom(type) do
     "#{path(name)}/#{uuid}-"
   end
 
-  def sequence(<< _ :: size(256), "-", seq :: binary >>) do
-    String.to_integer seq
+  def path({ type, _id} = name, << _ :: size(256), 45, _ :: size(80) >> = znode_name) when is_atom(type) do
+    "#{path(name)}/#{znode_name}"
+  end
+
+  def sequence(<< _ :: size(256), 45, seq :: size(80) >>) do
+    seq
+    |> to_string
+    |> String.to_integer
   end
 
   def sort(children) do
@@ -22,7 +24,6 @@ defmodule Highlander.Registry.ZK.Helpers do
   end
 
   def first(children) do
-    children
-    |> List.first
+    children |> List.first
   end
 end

--- a/lib/highlander/registry/zk/helpers.ex
+++ b/lib/highlander/registry/zk/helpers.ex
@@ -1,0 +1,28 @@
+defmodule Highlander.Registry.ZK.Helpers do
+  @base_path "/__shared_objects__"
+
+  def path({ type, id }) when is_atom(type) do
+    "#{@base_path}/#{type}/#{id}/"
+  end
+
+  def path({ type, _id} = name, << _ :: size(256), "-", _ :: binary >> = node_name) when is_atom(type) do
+    "#{path(name)}/#{node_name}"
+  end
+
+  def prefix({ type, _id} = name, << uuid :: size(256) >>) when is_atom(type) do
+    "#{path(name)}/#{uuid}-"
+  end
+
+  def sequence(<< _ :: size(256), "-", seq :: binary >>) do
+    String.to_integer seq
+  end
+
+  def sort(children) do
+    Enum.sort_by children, &sequence/1
+  end
+
+  def first(children) do
+    children
+    |> List.first
+  end
+end

--- a/lib/highlander/registry/zk/node.ex
+++ b/lib/highlander/registry/zk/node.ex
@@ -25,10 +25,10 @@ defmodule Highlander.Registry.ZK.ZNode do
   def init({type, _id} = name) when is_atom(type) do
     uuid = UUID.uuid4(:hex)
     path_prefix = prefix(name, uuid)
-    hostname = to_string Node.self
+    node_name = to_string Node.self
 
-    Logger.debug "#{node} creating #{path_prefix}: [#{hostname}] in zookeeper"
-    {:ok, created_path} = Zookeeper.Client.create(:zk, path_prefix, hostname, makepath: true, create_mode: :ephemeral_sequential)
+    Logger.debug "#{node} creating #{path_prefix}: [#{node_name}] in zookeeper"
+    {:ok, created_path} = Zookeeper.Client.create(:zk, path_prefix, node_name, makepath: true, create_mode: :ephemeral_sequential)
 
     znode_name = Path.basename(created_path)
     state = %{znode_name: znode_name, name: name}

--- a/lib/highlander/registry/zk/node.ex
+++ b/lib/highlander/registry/zk/node.ex
@@ -1,0 +1,36 @@
+defmodule Highlander.Registry.ZK.Node do
+  use GenServer
+  import Highlander.Registry.ZK.Helpers
+  alias Highlander.Registry.ZK
+
+  def start_link(name) do
+    GenServer.start_link __MODULE__, name
+  end
+
+  def first?(pid) do
+    GenServer.call(pid, :first?)
+  end
+
+  # Server
+
+  def init({type, _id} = name) when is_atom(type) do
+    uuid = UUID.uuid4(:hex)
+    path_prefix = prefix(name, uuid)
+    hostname = to_string Node.self
+
+    {:ok, created_path} = Zookeeper.Client.create(:zk, path_prefix, hostname, makepath: true, create_mode: :ephemeral_sequential)
+
+    node_name = Path.basename(created_path)
+    state = %{node_name: node_name, name: name}
+
+    {:ok, state}
+  end
+
+  def terminate(_reason, %{name: name, node_name: node_name}) do
+    Zookeeper.Client.delete(:zk, path(name, node_name))
+  end
+
+  def handle_call(:first?, _from, %{name: name, node_name: node_name}) do
+    ZK.first?(name, node_name)
+  end
+end

--- a/lib/highlander/shared/info.ex
+++ b/lib/highlander/shared/info.ex
@@ -1,37 +1,20 @@
 defmodule Highlander.Shared.Info do
+  require Logger
   alias Highlander.Shared.Info.Server
 
   def get(bucket) do
-    GenServer.call Server, {:get, bucket}
+    case Redix.command!(:redix, ~w(GET #{bucket})) do
+      nil -> %{}
+      "" -> %{}
+      value ->
+        Logger.debug "value in redis for #{bucket}: #{inspect value}"
+        Poison.decode!(value)
+    end
   end
 
   def set(bucket, info) do
-    GenServer.call Server, {:set, bucket, info}
-  end
-end
-
-defmodule Highlander.Shared.Info.Server do
-  use GenServer
-
-  # TODO: use redis or sqlite or something
-
-  @empty_info %{}
-
-  def start_link do
-    GenServer.start_link __MODULE__, [], name: __MODULE__
-  end
-
-  def init(_) do
-    {:ok, %{}}
-  end
-
-  def handle_call({:set, bucket, info}, _from, state) do
-    new_state = Map.put state, bucket, info
-    {:reply, info, new_state}
-  end
-
-  def handle_call({:get, bucket}, _from, state) do
-    info = Map.get(state, bucket, @empty_info)
-    {:reply, info, state}
+    json = Poison.encode!(info)
+    Logger.debug "setting into redis for #{bucket}: #{inspect json}"
+    Redix.command!(:redix, ~w(SET #{bucket} #{json}))
   end
 end

--- a/lib/highlander/supervisor.ex
+++ b/lib/highlander/supervisor.ex
@@ -6,12 +6,14 @@ defmodule Highlander.Supervisor do
   end
 
   def init(_) do
-    host = Application.fetch_env! :highlander, :zookeeper_host
+    zookeeper_host = Application.fetch_env! :highlander, :zookeeper_host
+    redis_host = Application.fetch_env! :highlander, :redis_host
 
     children = [
-      worker(Zookeeper.Client, [host, [stop_on_disconnect: true, name: :zk]], []),
+      worker(Zookeeper.Client, [zookeeper_host, [stop_on_disconnect: true, name: :zk]], []),
       worker(Highlander.Registry.Server, [], []),
-      worker(Highlander.Shared.Info.Server, [], []),
+      worker(Highlander.Registry.NodeCycleServer, [], []),
+      worker(Redix, [redis_host, [name: :redix]], []),
       supervisor(Highlander.Shared.Supervisor, [], [])
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,12 @@ defmodule Highlander.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     elixirc_paths: elixirc_paths(Mix.env),
      deps: deps()]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   def application do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,9 @@ defmodule Highlander.Mixfile do
 
   defp deps do
     [
-      {:zookeeper, github: "vishnevskiy/zookeeper-elixir"}
+      {:zookeeper, github: "vishnevskiy/zookeeper-elixir"},
+      {:redix, github: "whatyouhide/redix"},
+      {:poison, "~> 3.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "erlzk": {:git, "https://github.com/huaban/erlzk.git", "a005aab956e88686d8d9e719cb3937ae91c98b68", [ref: "a005aab956e88686d8d9e719cb3937ae91c98b68"]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
-  "redix": {:git, "https://github.com/whatyouhide/redix.git", "b76b1fcb63306875f4050dce7c625ac51a703bf6", []},
-  "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []},
-  "zookeeper": {:git, "https://github.com/vishnevskiy/zookeeper-elixir.git", "dc820122e9e2d69e7dadf8a2b079f01146d55c80", []}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "redix": {:git, "https://github.com/whatyouhide/redix.git", "7ff4f0491021e75f47d73d339ce9a8013bea59b8", []},
+  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], []},
+  "zookeeper": {:git, "https://github.com/vishnevskiy/zookeeper-elixir.git", "773f63583af4f3de923ddf6a07a686330ddd3a30", []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,6 @@
-%{"erlzk": {:git, "https://github.com/huaban/erlzk.git", "a005aab956e88686d8d9e719cb3937ae91c98b68", [ref: "a005aab956e88686d8d9e719cb3937ae91c98b68"]},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "erlzk": {:git, "https://github.com/huaban/erlzk.git", "a005aab956e88686d8d9e719cb3937ae91c98b68", [ref: "a005aab956e88686d8d9e719cb3937ae91c98b68"]},
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "redix": {:git, "https://github.com/whatyouhide/redix.git", "b76b1fcb63306875f4050dce7c625ac51a703bf6", []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []},
   "zookeeper": {:git, "https://github.com/vishnevskiy/zookeeper-elixir.git", "dc820122e9e2d69e7dadf8a2b079f01146d55c80", []}}

--- a/test/highlander_test.exs
+++ b/test/highlander_test.exs
@@ -5,7 +5,7 @@ defmodule HighlanderTest do
 
   setup do
     # clear out all actors in the db
-    Zookeeper.Client.delete :zk, "/__actors__", -1, true
+    Zookeeper.Client.delete :zk, "/__shared_objects__", -1, true
     # stop actor id 1 if it's running
     case Highlander.Shared.User.lookup("1") do
       pid when is_pid(pid) -> Process.exit(pid, :shutdown)

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,0 +1,67 @@
+# Copied from <https://github.com/phoenixframework/phoenix_pubsub/blob/master/test/support/cluster.ex>
+
+defmodule Highlander.Test.Cluster do
+  def spawn do
+    # Turn node into a distributed node with the given long name
+    :net_kernel.start([:"primary@127.0.0.1"])
+
+    # Allow spawned nodes to fetch all code from this node
+    :erl_boot_server.start([])
+    allow_boot to_char_list("127.0.0.1")
+
+    nodes = Application.get_env(:highlander, :spawn_nodes, [])
+
+    nodes
+    |> Enum.map(&Task.async(fn -> spawn_node(&1) end))
+    |> Enum.map(&Task.await(&1, 30_000))
+  end
+
+  defp spawn_node(node_host) do
+    {:ok, node} = :slave.start(to_char_list("127.0.0.1"), node_name(node_host), inet_loader_args())
+    add_code_paths(node)
+    transfer_configuration(node)
+    ensure_applications_started(node)
+    {:ok, node}
+  end
+
+  defp rpc(node, module, function, args) do
+    :rpc.block_call(node, module, function, args)
+  end
+
+  defp inet_loader_args do
+    to_char_list("-loader inet -hosts 127.0.0.1 -setcookie #{:erlang.get_cookie()}")
+  end
+
+  defp allow_boot(host) do
+    {:ok, ipv4} = :inet.parse_ipv4_address(host)
+    :erl_boot_server.add_slave(ipv4)
+  end
+
+  defp add_code_paths(node) do
+    rpc(node, :code, :add_paths, [:code.get_path()])
+  end
+
+  defp transfer_configuration(node) do
+    for {app_name, _, _} <- Application.loaded_applications do
+      for {key, val} <- Application.get_all_env(app_name) do
+        rpc(node, Application, :put_env, [app_name, key, val])
+      end
+    end
+  end
+
+  defp ensure_applications_started(node) do
+    rpc(node, Application, :ensure_all_started, [:mix])
+    rpc(node, Mix, :env, [Mix.env()])
+    for {app_name, _, _} <- Application.loaded_applications do
+      rpc(node, Application, :ensure_all_started, [app_name])
+    end
+  end
+
+  defp node_name(node_host) do
+    node_host
+    |> to_string
+    |> String.split("@")
+    |> Enum.at(0)
+    |> String.to_atom
+  end
+end

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,6 +1,8 @@
 # Copied from <https://github.com/phoenixframework/phoenix_pubsub/blob/master/test/support/cluster.ex>
 
-defmodule Highlander.Test.Cluster do
+defmodule HighlanderTest.Cluster do
+  require Logger
+
   def spawn do
     # Turn node into a distributed node with the given long name
     :net_kernel.start([:"primary@127.0.0.1"])
@@ -12,7 +14,7 @@ defmodule Highlander.Test.Cluster do
     nodes = Application.get_env(:highlander, :spawn_nodes, [])
 
     nodes
-    |> Enum.map(&Task.async(fn -> spawn_node(&1) end))
+    |> Enum.map(&Task.async(fn -> {:ok, _node} = spawn_node(&1) end))
     |> Enum.map(&Task.await(&1, 30_000))
   end
 

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,0 +1,32 @@
+defmodule HighlanderTest.Helpers do
+  def alive?(pid) do
+    on_node pid, Process, :alive?, [pid]
+  end
+
+  def exit(pid, reason \\ :shutdown) when is_pid(pid) do
+    on_node pid, Process, :exit, [pid, reason]
+  end
+
+  def cleanup(pid) when is_pid(pid) do
+    on_node pid, __MODULE__, :cleanup_locally, [pid]
+  end
+
+  def cleanup_locally(pid) when is_pid(pid) do
+    Process.exit pid, :shutdown
+    ref = Process.monitor pid
+    receive do
+      {:DOWN, ^ref, :process, _, _} -> :ok
+    end
+  end
+
+  defp on_node(pid, module, fun, args \\ []) do
+    me = Node.self
+    case Kernel.node(pid) do
+      :"nonode@nohost" ->
+        raise "cannot find node the pid was created on"
+      ^me -> apply(module, fun, args)
+      node_name ->
+        :rpc.call node_name, module, fun, args
+    end
+  end
+end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,22 +1,45 @@
 # Basically copied from <https://github.com/phoenixframework/phoenix_pubsub/blob/master/test/support/node_case.ex>
 
-defmodule Highlander.Test.NodeCase do
+defmodule HighlanderTest.NodeCase do
   @timeout 500
+  @primary :"primary@127.0.0.1"
+  @node1 :"node1@127.0.0.1"
+  @node2 :"node2@127.0.0.1"
 
   defmacro __using__(_opts) do
     quote do
-      use ExUnit.Case, async: true
+      use ExUnit.Case
       import unquote(__MODULE__)
       @moduletag :clustered
 
       @timeout unquote(@timeout)
+      @primary unquote(@primary)
+      @node1 unquote(@node1)
+      @node2 unquote(@node2)
     end
   end
 
-  # example using call_node from Phoenix
-  # def start_tracker(node_name, opts) do
-  #   call_node(node_name, fn -> start_tracker(opts) end)
-  # end
+  def startup_user(node_name, id) do
+    call_node(node_name, fn -> Highlander.Shared.User.startup(id) end)
+  end
+
+  def set_user_info(node_name, id, info) do
+    call_node(node_name, fn -> Highlander.Shared.User.set_info(id, info) end)
+  end
+
+  def process_alive?(node_name, pid) when is_pid(pid) do
+    call_node(node_name, fn -> Process.alive?(pid) end)
+  end
+
+  def cleanup_on_node(node_name, pid) do
+    call_node(node_name, fn ->
+      Process.exit pid, :shutdown
+      ref = Process.monitor pid
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      end
+    end)
+  end
 
   def flush do
     receive do
@@ -30,7 +53,7 @@ defmodule Highlander.Test.NodeCase do
     parent = self
     ref = make_ref
 
-    pid = Node.spawn_link(node, fn ->
+    Node.spawn_link(node, fn ->
       result = func.()
       send parent, {ref, result}
       ref = Process.monitor(parent)
@@ -40,9 +63,9 @@ defmodule Highlander.Test.NodeCase do
     end)
 
     receive do
-      {^ref, result} -> {pid, result}
+      {^ref, result} -> result
     after
-      @timeout -> {pid, {:error, :timeout}}
+      @timeout -> {:error, :timeout}
     end
   end
 end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,0 +1,48 @@
+# Basically copied from <https://github.com/phoenixframework/phoenix_pubsub/blob/master/test/support/node_case.ex>
+
+defmodule Highlander.Test.NodeCase do
+  @timeout 500
+
+  defmacro __using__(_opts) do
+    quote do
+      use ExUnit.Case, async: true
+      import unquote(__MODULE__)
+      @moduletag :clustered
+
+      @timeout unquote(@timeout)
+    end
+  end
+
+  # example using call_node from Phoenix
+  # def start_tracker(node_name, opts) do
+  #   call_node(node_name, fn -> start_tracker(opts) end)
+  # end
+
+  def flush do
+    receive do
+      _ -> flush
+    after
+      0 -> :ok
+    end
+  end
+
+  defp call_node(node, func) do
+    parent = self
+    ref = make_ref
+
+    pid = Node.spawn_link(node, fn ->
+      result = func.()
+      send parent, {ref, result}
+      ref = Process.monitor(parent)
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      end
+    end)
+
+    receive do
+      {^ref, result} -> {pid, result}
+    after
+      @timeout -> {pid, {:error, :timeout}}
+    end
+  end
+end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,71 +1,20 @@
 # Basically copied from <https://github.com/phoenixframework/phoenix_pubsub/blob/master/test/support/node_case.ex>
 
 defmodule HighlanderTest.NodeCase do
-  @timeout 500
   @primary :"primary@127.0.0.1"
   @node1 :"node1@127.0.0.1"
   @node2 :"node2@127.0.0.1"
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
-      use ExUnit.Case
+      use ExUnit.Case, unquote(opts)
       import unquote(__MODULE__)
+      import HighlanderTest.Helpers
       @moduletag :clustered
 
-      @timeout unquote(@timeout)
       @primary unquote(@primary)
       @node1 unquote(@node1)
       @node2 unquote(@node2)
-    end
-  end
-
-  def startup_user(node_name, id) do
-    call_node(node_name, fn -> Highlander.Shared.User.startup(id) end)
-  end
-
-  def set_user_info(node_name, id, info) do
-    call_node(node_name, fn -> Highlander.Shared.User.set_info(id, info) end)
-  end
-
-  def process_alive?(node_name, pid) when is_pid(pid) do
-    call_node(node_name, fn -> Process.alive?(pid) end)
-  end
-
-  def cleanup_on_node(node_name, pid) do
-    call_node(node_name, fn ->
-      Process.exit pid, :shutdown
-      ref = Process.monitor pid
-      receive do
-        {:DOWN, ^ref, :process, _, _} -> :ok
-      end
-    end)
-  end
-
-  def flush do
-    receive do
-      _ -> flush
-    after
-      0 -> :ok
-    end
-  end
-
-  defp call_node(node, func) do
-    parent = self
-    ref = make_ref
-
-    Node.spawn_link(node, fn ->
-      result = func.()
-      send parent, {ref, result}
-      ref = Process.monitor(parent)
-      receive do
-        {:DOWN, ^ref, :process, _, _} -> :ok
-      end
-    end)
-
-    receive do
-      {^ref, result} -> result
-    after
-      @timeout -> {:error, :timeout}
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,9 @@
-ExUnit.start()
+exclude = Keyword.get(ExUnit.configuration(), :exclude, [])
+
+cond do
+  :clustered in exclude ->
+    ExUnit.start()
+  true ->
+    Highlander.Test.Cluster.spawn()
+    ExUnit.start()
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,6 @@ cond do
   :clustered in exclude ->
     ExUnit.start()
   true ->
-    Highlander.Test.Cluster.spawn()
+    HighlanderTest.Cluster.spawn()
     ExUnit.start()
 end


### PR DESCRIPTION
Processes are registered and discoverable across nodes. Currently a process will first check it's in-memory pid map for a name and then fallback to zookeeper to discover the node name that may have that named process. It could make sense to cache the remote PIDs for a short time to prevent hitting zookeeper too often, but I wanted to avoid all caching for now.